### PR TITLE
chore: update changes to follow style guide

### DIFF
--- a/lib/booleans/and/index.test.ts
+++ b/lib/booleans/and/index.test.ts
@@ -52,8 +52,7 @@ test("returns an error when one or more operands is an error", async () => {
 	})()
 
 	expect(isLeft(failure)).toBeTruthy()
-	// expect((failure as Left<Array<string>>).left).toEqual([
-	// 	"Unknown operation.",
-	// 	"Unknown operation.",
-	// ])
+	expect((failure as Left<Array<string>>).left).toEqual([
+		"Unknown operation: fail.",
+	])
 })

--- a/lib/booleans/and/index.test.ts
+++ b/lib/booleans/and/index.test.ts
@@ -52,8 +52,8 @@ test("returns an error when one or more operands is an error", async () => {
 	})()
 
 	expect(isLeft(failure)).toBeTruthy()
-	//expect((failure as Left<Array<string>>).left).toEqual([
-	//	"Unknown operation.",
-	//	"Unknown operation.",
-	//])
+	// expect((failure as Left<Array<string>>).left).toEqual([
+	// 	"Unknown operation.",
+	// 	"Unknown operation.",
+	// ])
 })

--- a/lib/booleans/and/index.ts
+++ b/lib/booleans/and/index.ts
@@ -9,9 +9,9 @@ type And = (op: AndOperation) => IO<Either<Array<string>, boolean>>
 const and: And = op => {
 	return pipe(
 		op.operands,
-		traverseArray(_ => composeOperations(_)()),
+		traverseArray(_ => composeOperations(_)()), // nice, but only returns first error: is that what we want?
 		match(
-			errs => () => left(errs),
+			errors => () => left(errors),
 			_ => () => right(true),
 		),
 	)

--- a/lib/booleans/and/index.ts
+++ b/lib/booleans/and/index.ts
@@ -1,10 +1,11 @@
 import type { Either } from "fp-ts/lib/Either"
 import { left, right, traverseArray, match } from "fp-ts/lib/Either"
 import { pipe } from "fp-ts/lib/function"
+import { IO } from "fp-ts/lib/IO"
 
-import { composeOperations } from "../../operations/compose"
+import composeOperations from "../../operations/compose"
 
-type And = (op: AndOperation) => () => Either<Array<string>, boolean>
+type And = (op: AndOperation) => IO<Either<Array<string>, boolean>>
 const and: And = op => {
 	return pipe(
 		op.operands,

--- a/lib/booleans/or/index.test.ts
+++ b/lib/booleans/or/index.test.ts
@@ -49,8 +49,6 @@ test("returns an error when all operands are errors", async () => {
 		returns: "boolean",
 	})()
 
-	console.log("OR failure", JSON.stringify(failure, null, 2))
-
 	expect(isLeft(failure)).toBeTruthy()
 	//expect((failure as Left<Array<string>>).left).toEqual([
 	//	"Unknown operation.",

--- a/lib/mathematical/add/index.ts
+++ b/lib/mathematical/add/index.ts
@@ -1,7 +1,7 @@
 import { pipe } from "fp-ts/lib/function"
 import { right, traverseArray, match, left } from "fp-ts/lib/Either"
 
-import { evaluateNumericOperations } from "../../operations/compose"
+import evaluateNumericOperations from "../../operations/compose/evaluateNumericOperations"
 
 import { ADDITION_IDENTITY } from "../../constants"
 

--- a/lib/mathematical/add/index.ts
+++ b/lib/mathematical/add/index.ts
@@ -16,7 +16,7 @@ const add: Add = op => {
 		op.addends,
 		traverseArray(lift),
 		match(
-			errs => () => left(errs),
+			errors => () => left(errors),
 			nums => () =>
 				right(nums.reduce((sum, operand) => sum + operand, ADDITION_IDENTITY)),
 		),

--- a/lib/operations/compose/evaluateBooleanOperation/index.ts
+++ b/lib/operations/compose/evaluateBooleanOperation/index.ts
@@ -1,0 +1,19 @@
+import and from "../../../booleans/and"
+import or from "../../../booleans/or"
+import { left } from "../../../fp/either"
+
+type EvaluateBooleanOperations = (
+	o: BooleanOperation,
+) => () => Either<Array<string>, boolean>
+const evaluateBooleanOperation: EvaluateBooleanOperations = op => {
+	switch (op.operation) {
+		case "and":
+			return and(op)
+		case "or":
+			return or(op)
+		default:
+			return () => left([`Invalid boolean operation ${op}`])
+	}
+}
+
+export default evaluateBooleanOperation

--- a/lib/operations/compose/evaluateNumericOperations/index.ts
+++ b/lib/operations/compose/evaluateNumericOperations/index.ts
@@ -1,0 +1,42 @@
+import add from "../../../mathematical/add"
+import compareNumbers from "../../../logical/compareNumbers"
+import divide from "../../../mathematical/divide"
+import multiply from "../../../mathematical/multiply"
+import negate from "../../../mathematical/negate"
+import power from "../../../mathematical/power"
+import root from "../../../mathematical/root"
+import subtract from "../../../mathematical/subtract"
+import { left } from "../../../fp/either"
+
+type EvaluateNumericOperations = (
+	o: NumericOperation,
+) => () => Either<Array<string>, number>
+const evaluateNumericOperations: EvaluateNumericOperations = op => {
+	switch (op.operation) {
+		case "add":
+			return add(op)
+		case "divide":
+			return divide(op)
+		case "multiply":
+			return multiply(op)
+		case "negate":
+			return negate(op)
+		case "power":
+			return power(op)
+		case "root":
+			return root(op)
+		case "subtract":
+			return subtract(op)
+		case "equalTo":
+		case "greaterThan":
+		case "lessThan":
+		case "noLessThan":
+		case "noMoreThan":
+		case "unequalTo":
+			return compareNumbers(op)
+		default:
+			return () => left([`Invalid numeric operation ${op}`])
+	}
+}
+
+export default evaluateNumericOperations

--- a/lib/operations/compose/evaluateUnitOperations/index.ts
+++ b/lib/operations/compose/evaluateUnitOperations/index.ts
@@ -1,0 +1,16 @@
+import fromFormInput from "../../../injectors/formInput"
+import { left } from "../../../fp/either"
+
+type EvaluateUnitOperations = (
+	o: UnitOperation,
+) => () => Either<Array<string>, number>
+const evaluateUnitOperations: EvaluateUnitOperations = op => {
+	switch (op.operation) {
+		case "formInput":
+			return fromFormInput(op)
+		default:
+			return () => left([`Invalid unit operation ${op}`])
+	}
+}
+
+export default evaluateUnitOperations

--- a/lib/operations/compose/index.ts
+++ b/lib/operations/compose/index.ts
@@ -22,7 +22,7 @@ const composeOperations: ComposeOperations = op => {
 		return evaluateUnitOperations(op)
 	}
 
-	return () => left([`Unknown operation ${op}`])
+	return () => left([`Unknown operation: ${op.operation}.`])
 }
 
 export default composeOperations

--- a/lib/operations/compose/index.ts
+++ b/lib/operations/compose/index.ts
@@ -1,82 +1,14 @@
 import type { Either } from "fp-ts/lib/Either"
 import { left } from "fp-ts/lib/Either"
 
-import add from "../../numerical/add"
-import and from "../../booleans/and"
-import compareNumbers from "../../logical/compareNumbers"
-import divide from "../../numerical/divide"
-import fromFormInput from "../../injectors/formInput"
-import multiply from "../../numerical/multiply"
-import negate from "../../numerical/negate"
-import or from "../../booleans/or"
-import power from "../../numerical/power"
-import root from "../../numerical/root"
-import subtract from "../../numerical/subtract"
+import evaluateNumericOperations from "./evaluateNumericOperations"
+import evaluateBooleanOperation from "./evaluateBooleanOperation"
+import evaluateUnitOperations from "./evaluateUnitOperations"
 import {
 	isBooleanOperation,
-	isFailOperation,
 	isNumericOperation,
 	isUnitOperation,
 } from "../../operations"
-
-const EncounteredFailureMessage = "Encountered a failed operation, aborting"
-
-type EvaluateNumericOperations = (
-	o: NumericOperation,
-) => () => Either<Array<string>, number>
-const evaluateNumericOperations: EvaluateNumericOperations = op => {
-	switch (op.operation) {
-		case "add":
-			return add(op)
-		case "multiply":
-			return multiply(op)
-		case "subtract":
-			return subtract(op)
-		case "divide":
-			return divide(op)
-		case "power":
-			return power(op)
-		case "root":
-			return root(op)
-		case "negate":
-			return negate(op)
-		case "equalTo":
-		case "greaterThan":
-		case "lessThan":
-		case "noLessThan":
-		case "noMoreThan":
-		case "unequalTo":
-			return compareNumbers(op)
-		default:
-			return () => left([`Invalid numeric operation ${op}`])
-	}
-}
-
-type EvaluateBooleanOperations = (
-	o: BooleanOperation,
-) => () => Either<Array<string>, boolean>
-const evaluateBooleanOperation: EvaluateBooleanOperations = op => {
-	switch (op.operation) {
-		case "and":
-			return and(op)
-		case "or":
-			return or(op)
-		default:
-			return () => left([`Invalid boolean operation ${op}`])
-	}
-}
-
-type EvaluateUnitOperations = (
-	o: UnitOperation,
-) => () => Either<Array<string>, number>
-const evaluateUnitOperations: EvaluateUnitOperations = op => {
-	switch (op.operation) {
-		case "formInput":
-			return fromFormInput(op)
-		default:
-			return () => left([`Invalid unit operation ${op}`])
-	}
-}
 
 type ComposeOperations = (
 	o: Operation,
@@ -88,17 +20,9 @@ const composeOperations: ComposeOperations = op => {
 		return evaluateBooleanOperation(op)
 	} else if (isUnitOperation(op)) {
 		return evaluateUnitOperations(op)
-	} else if (isFailOperation(op)) {
-		return () => left([EncounteredFailureMessage])
 	}
 
 	return () => left([`Unknown operation ${op}`])
 }
 
-export {
-	EncounteredFailureMessage,
-	composeOperations,
-	evaluateUnitOperations,
-	evaluateBooleanOperation,
-	evaluateNumericOperations,
-}
+export default composeOperations

--- a/lib/operations/index.ts
+++ b/lib/operations/index.ts
@@ -10,8 +10,8 @@ const isBooleanOperation = (o: any): o is BooleanOperation =>
 const isUnitOperation = (o: any): o is UnitOperation =>
 	notNullish(o) && o["returns"] === "unit"
 
-const isFailOperation = (o: any): o is FailOperation =>
-	notNullish(o) && o["returns"] === "error"
+// const isFailOperation = (o: any): o is FailOperation =>
+// 	notNullish(o) && o["returns"] === "error"
 
 const isAddOperation = (o: any): o is AddOperation =>
 	isNumericOperation(o) && o.operation === "add"
@@ -31,6 +31,6 @@ export {
 	isBooleanOperation,
 	isUnitOperation,
 	isAddOperation,
-	isFailOperation,
+	// isFailOperation,
 	AddOperation,
 }

--- a/lib/utilities/getOperands/index.ts
+++ b/lib/utilities/getOperands/index.ts
@@ -1,6 +1,6 @@
 import { right } from "../../fp/either"
 
-import { composeOperations } from "../../operations/compose"
+import composeOperations from "../../operations/compose"
 
 const getOperands =
 	<T>(operands: Array<T | Operation>) =>


### PR DESCRIPTION
The FailOp is only intended for testing. Got a better way? We could just break some other op, I suppose. Hmm. Maybe we could nest the and op and break that ... will think on it.

Thus the commented out expects. I changed this, but left the guard commented out just in case.

I was confused by this:

```ts
const AddOperation = (
  lhs: number | NumericOperation,
  rhs: number | NumericOperation,
): AddOperation => ({
  addends: [lhs, rhs] as const,
  operation: "add",
  returns: "number",
})
```

As addition is associative _and_ commutative, I don't see any reason to limit ourselves to two addends. Ditto for multiplication. Is there an advantage to this I'm not seeing? Open to discussion.

It will really help if you read (ok, skim) the style guide. I know it's a lot and getting bigger. The other option is that for the next few weeks you do things and then I say "not like that" and change them. Will that drive you nuts? I'm OK either way.

One of my inviolable rules is **only one export per file and that as the default**. There are some exceptions, but not for most functions. More than one function or component in a file is a major cognitive load, and I am all about reducing cognitive load. Collapsing them is not the same. Separate file, please.

(Case in point. I am looking up `traverseArray` in the source code. The `Either.ts` file is 1800+ lines. FFS. So, minor rant: You want to know why FP is _never_ going to catch on widely? It's because 99.999% of functional programmers are utter arrogant pricks. It's like a club.
If you don't have a CS degree (graduate preferred) and have a minor (at least) in math and know the lambda calculus inside and out and maybe category theory, too, and write Haskell in your sleep then you should find something else to do more in line with your meager talents. Yeah. How's that working out? Not so good, eh?)

Also, no abbreviations, please. Not "errs" – "errors". Even that small a thing. It adds up. With "errors" I don't have to spend that 1/10 of a second thinking, "Oh ... that's errors." And actually, under the current setup, it should be "error" as it's a single one, not an array of them. No?

Switching to a Haskell approach is pretty cool, but it will take this old brain a while to fully adapt. So, for example, I am not used to a `pipe` that takes the parameters as the first argument. (My experience with pipe is what fp-ts calls `flow`.) I am curious as to how this is better. I suspect it is their way of approximating the `pipe` operator (|> IIRC).

What does `traverseArray` do? How is it different from `map`. Obviously, it takes the array of operands, calls `composeOperations` on each, and then sends the output to `match`. It appears to me that it returns the first left it finds, or, I guess, the last right. Is that correct?

P.S. It's after midnight and I've been going for roughly 13 hours. Exhausted. So if any of these seems brain dead, well, I mostly am. I'll be better tomorrow, I hope.