### PR TITLE
align return types of composeOperations

### DIFF
--- a/lib/operations/compose/evaluateLookupOperation/index.ts
+++ b/lib/operations/compose/evaluateLookupOperation/index.ts
@@ -1,18 +1,21 @@
 import type { CastableValue, LookupOperation, Reify } from "../../../types"
 
+import { Option } from "@sitebender/fp/lib/option"
 import { Either, left } from "@sitebender/fp/lib/either"
 import lookup from "../../../lookup/literal"
 
 export type EvaluateLookupOperation = (
 	OperationMultiply: LookupOperation,
-) => () => Either<Array<string>, Reify<CastableValue>>
+) => (
+	input: Option<Reify<CastableValue>>,
+) => Either<Array<string>, Option<Reify<CastableValue>>>
 
-const evaluateLookupOperation: EvaluateLookupOperation = op => {
+const evaluateLookupOperation: EvaluateLookupOperation = op => input => {
 	switch (op.operation) {
 		case "literalLookup":
-			return lookup(op)
+			return lookup(op)(input)
 		default:
-			return () => left([`Invalid numeric operation: ${op.operation}.`])
+			return left([`Invalid numeric operation: ${op.operation}.`])
 	}
 }
 

--- a/lib/operations/compose/index.ts
+++ b/lib/operations/compose/index.ts
@@ -1,5 +1,4 @@
-import { Either, left } from "@sitebender/fp/lib/either"
-import { Option } from "@sitebender/fp/lib/option"
+import { Option, none, some } from "@sitebender/fp/lib/option"
 import evaluateBooleanOperation from "./evaluateBooleanOperation"
 import evaluateInjectableOperation from "./evaluateInjectableOperation"
 import evaluateNumericOperation from "./evaluateNumericOperation"
@@ -8,23 +7,32 @@ import isInjectableOperation from "../../utilities/isUnitOperation"
 import isNumericOperation from "../../utilities/isNumericOperation"
 import isLookupOperation from "../../utilities/isLookupOperation"
 import evaluateLookupOperation from "./evaluateLookupOperation"
-import { Operation } from "../../types"
+import { CastableValue, Operation, Reify } from "../../types"
+import { pipe } from "@sitebender/fp/lib/functions"
+import { OperationResult } from "../operationResult/types"
+import { left, map } from "@sitebender/fp/lib/either"
 
 export type ComposeOperations = (
 	o: Operation,
-) => () => Either<Array<string>, Option<number> | number | boolean | string>
-const composeOperations: ComposeOperations = op => {
-	if (isNumericOperation(op)) {
-		return evaluateNumericOperation(op)
-	} else if (isBooleanOperation(op)) {
-		return evaluateBooleanOperation(op)
-	} else if (isInjectableOperation(op)) {
-		return evaluateInjectableOperation(op)
-	} else if (isLookupOperation(op)) {
-		return evaluateLookupOperation(op)
-	}
+) => (
+	input?: Option<Reify<CastableValue>>,
+) => OperationResult<Reify<CastableValue>>
+const composeOperations: ComposeOperations =
+	op =>
+	(input = none) => {
+		if (isNumericOperation(op)) {
+			return evaluateNumericOperation(op)(input as Option<number>)
+		} else if (isBooleanOperation(op)) {
+			return pipe(evaluateBooleanOperation(op)(), map(some)) as OperationResult<
+				Reify<CastableValue>
+			>
+		} else if (isInjectableOperation(op)) {
+			return evaluateInjectableOperation(op)(input)
+		} else if (isLookupOperation(op)) {
+			return evaluateLookupOperation(op)(input)
+		}
 
-	return () => left([`Unknown operation: ${op}.`])
-}
+		return left([`Unknown operation: ${op}.`])
+	}
 
 export default composeOperations


### PR DESCRIPTION
The compose function needs to share the return type of all of the evaluation functions.
At the moment this means sharing a type of `(input: Option<Reify<CastableValues>>) => OperationResult<Reify<CastableValues>>` so that all the calls are compatible.
Later this week I'll replace `Reify<CastableValues>` with something else that's less annoying to type with a better name.
I'll also look at adding proper input type checks for `evaluateNumericOperation` to get rid of that nasty cast.