### PR TITLE
Chas

### DIFF
--- a/lib/makeInjector/injectors/injectFromElement/index.test.ts
+++ b/lib/makeInjector/injectors/injectFromElement/index.test.ts
@@ -1,0 +1,77 @@
+import { test, expect } from "vitest"
+import { JSDOM } from "jsdom"
+
+import left from "@sitebender/fp/lib/either/left"
+import some from "@sitebender/fp/lib/option/some"
+import right from "@sitebender/fp/lib/either/right"
+
+import injectFromElement from "."
+import {
+	SbInjectFromElement,
+	SbInjectorType,
+	SbOperationTags,
+} from "../../../types"
+
+const dom = new JSDOM(
+	`<!DOCTYPE html>
+<output id="fu">666</output>
+<output id="man">  ha  </output>
+<output id="chu">true</output>
+`,
+)
+
+globalThis.document = dom.window.document
+
+test("[injectFromElement] (injectors) returns success for number", () => {
+	const operation = {
+		_tag: SbOperationTags.injector,
+		injectedDataType: "number",
+		type: SbInjectorType.element,
+		source: {
+			id: "fu",
+		},
+	} as SbInjectFromElement<"number">
+
+	expect(injectFromElement(operation)()()).toEqual(right(some(666)))
+})
+
+test("[injectFromElement] (injectors) returns success for string", () => {
+	const operation = {
+		_tag: SbOperationTags.injector,
+		injectedDataType: "string",
+		type: SbInjectorType.element,
+		source: {
+			id: "man",
+		},
+	} as SbInjectFromElement<"string">
+
+	expect(injectFromElement(operation)()()).toEqual(right(some("ha")))
+})
+
+test("[injectFromElement] (injectors) returns success for boolean", () => {
+	const operation = {
+		_tag: SbOperationTags.injector,
+		injectedDataType: "boolean",
+		type: SbInjectorType.element,
+		source: {
+			id: "chu",
+		},
+	} as SbInjectFromElement<"boolean">
+
+	expect(injectFromElement(operation)()()).toEqual(right(some(true)))
+})
+
+test("[injectFromElement] (injectors) returns error if no such element", () => {
+	const operation = {
+		_tag: SbOperationTags.injector,
+		injectedDataType: "boolean",
+		type: SbInjectorType.element,
+		source: {
+			id: "nobody",
+		},
+	} as SbInjectFromElement<"boolean">
+
+	expect(injectFromElement(operation)()()).toEqual(
+		left(["Form element at `#nobody` not found."]),
+	)
+})

--- a/lib/makeInjector/injectors/injectFromElement/index.ts
+++ b/lib/makeInjector/injectors/injectFromElement/index.ts
@@ -1,0 +1,34 @@
+import type {
+	SbCastableValue,
+	SbInjectFromElement,
+	Reify,
+} from "../../../types"
+
+import { Option, none } from "@sitebender/fp/lib/option"
+import castValue from "../../../utilities/castValue"
+import getValue from "../../../old/utilities/getValue"
+import { pipe } from "@sitebender/fp/lib/functions"
+import { OperationResult } from "../../../old/operations/operationResult/types"
+import { mapEither } from "../../../old/operations/operationResult"
+import { Lazy } from "@sitebender/fp/lib/lazy"
+
+export type FromElementF = <T extends SbCastableValue>(
+	op: SbInjectFromElement<T>,
+) => (input?: Option<Reify<T>>) => Lazy<OperationResult<Reify<T>>>
+
+const injectFromElement: FromElementF =
+	op =>
+	(_ = none) => {
+		if (op.eager) {
+			const item = pipe(
+				getValue(op.source)(),
+				mapEither(castValue(op.injectedDataType)),
+			)
+			return () => item
+		}
+
+		return () =>
+			pipe(getValue(op.source)(), mapEither(castValue(op.injectedDataType)))
+	}
+
+export default injectFromElement

--- a/lib/makeInjector/injectors/injectFromElement/index.ts
+++ b/lib/makeInjector/injectors/injectFromElement/index.ts
@@ -8,8 +8,8 @@ import { Option, none } from "@sitebender/fp/lib/option"
 import castValue from "../../../utilities/castValue"
 import getValue from "../../../old/utilities/getValue"
 import { pipe } from "@sitebender/fp/lib/functions"
-import { OperationResult } from "../../../old/operations/operationResult/types"
-import { mapEither } from "../../../old/operations/operationResult"
+import type { OperationResult } from "../../../operations/operationResult/types"
+import { mapEither } from "../../../operations/operationResult"
 import { Lazy } from "@sitebender/fp/lib/lazy"
 
 export type FromElementF = <T extends SbCastableValue>(

--- a/lib/makeInjector/injectors/injectFromFormInput/index.test.ts
+++ b/lib/makeInjector/injectors/injectFromFormInput/index.test.ts
@@ -33,6 +33,6 @@ test("[injectFromFormInput] (injectors) returns a failure for a non-existent key
 	const operation = makeInjectedNumberFromForm({ name: "bar" })
 
 	expect(injectFromFormInput(operation)()()).toEqual(
-		left(["Form element `bar` not found."]),
+		left(["Form element at `[name=bar]` not found."]),
 	)
 })

--- a/lib/makeInjector/injectors/injectFromFormInput/index.test.ts
+++ b/lib/makeInjector/injectors/injectFromFormInput/index.test.ts
@@ -15,20 +15,23 @@ const dom = new JSDOM(
 globalThis.document = dom.window.document
 
 test("[injectFromFormInput] (injectors) returns success", () => {
-	const operation = makeInjectedNumberFromForm({ name: "foo", tagName: "foo" })
+	const operation = makeInjectedNumberFromForm({ name: "foo" })
+
 	expect(injectFromFormInput(operation)()()).toEqual(right(some(12)))
 })
 
 test("[injectFromFormInput] (injectors) returns success", () => {
 	const operation = {
-		...makeInjectedNumberFromForm({ name: "foo", tagName: "foo" }),
+		...makeInjectedNumberFromForm({ name: "foo" }),
 		eager: true,
 	}
+
 	expect(injectFromFormInput(operation)()()).toEqual(right(some(12)))
 })
 
-test("[injectFromFormInput] (injectors) returns a failure for a non-existant key", () => {
-	const operation = makeInjectedNumberFromForm({ name: "bar", tagName: "bar" })
+test("[injectFromFormInput] (injectors) returns a failure for a non-existent key", () => {
+	const operation = makeInjectedNumberFromForm({ name: "bar" })
+
 	expect(injectFromFormInput(operation)()()).toEqual(
 		left(["Form element `bar` not found."]),
 	)

--- a/lib/makeInjector/injectors/injectFromLookupTable/index.test.ts
+++ b/lib/makeInjector/injectors/injectFromLookupTable/index.test.ts
@@ -26,7 +26,6 @@ const operation: SbInjectFromLookupTable<"number"> = {
 		type: SbInjectorType.form,
 		source: {
 			name: "foo",
-			tagName: "foo",
 		},
 	},
 	test: [
@@ -63,7 +62,7 @@ test("[injectFromLookupTable] (injectors) returns a value for a mapped key", () 
 	expect(injectFromLookupTable(operation)()).toEqual(right(some(0.5)))
 })
 
-test("[injectFromLookupTable] (injectors) returns a failure for a non-existant key", () => {
+test("[injectFromLookupTable] (injectors) returns a failure for a non-existent key", () => {
 	const dom = new JSDOM(
 		`<!DOCTYPE html>
 	<input name="foo" type="text" value="1000">

--- a/lib/makeInjector/injectors/injectFromMap/index.test.ts
+++ b/lib/makeInjector/injectors/injectFromMap/index.test.ts
@@ -23,7 +23,6 @@ const operation: SbInjectFromMap<"string"> = {
 		type: SbInjectorType.form,
 		source: {
 			name: "foo",
-			tagName: "foo",
 		},
 	},
 	type: SbInjectorType.map,

--- a/lib/old/utilities/getValue/getFromInnerHtml/index.ts
+++ b/lib/old/utilities/getValue/getFromInnerHtml/index.ts
@@ -1,0 +1,8 @@
+import { Option, none, some } from "@sitebender/fp/lib/option"
+
+export type GetFromInnerHtmlF = (element: HTMLElement) => () => Option<string>
+
+const getFromInnerHtml: GetFromInnerHtmlF = element => () =>
+	element.innerHTML ? some(element.innerHTML.trim()) : none
+
+export default getFromInnerHtml

--- a/lib/old/utilities/getValue/getSelector/index.ts
+++ b/lib/old/utilities/getValue/getSelector/index.ts
@@ -1,0 +1,25 @@
+import { SbFormInjectorData } from "../../../../types"
+
+export type GetSelectorF = (source: SbFormInjectorData) => string
+
+const getSelector: GetSelectorF = source => {
+	const { form, id, name, selector, tagName = "" } = source || {}
+
+	const formId = form ? `#${form} ` : ""
+
+	if (selector) {
+		return selector
+	}
+
+	if (id) {
+		return `#${id}`
+	}
+
+	if (name) {
+		return `${formId}${tagName}[name=${name}]`
+	}
+
+	return `${formId}${tagName}`
+}
+
+export default getSelector

--- a/lib/old/utilities/getValue/index.test.ts
+++ b/lib/old/utilities/getValue/index.test.ts
@@ -44,8 +44,8 @@ test("gets the value from form inputs", () => {
 	expect(getValue({ name: "nope", tagName: "INPUT" })()).toStrictEqual(
 		right(none),
 	)
-	expect(getValue({ name: "bob", tagName: "UNKNOWN" })()).toStrictEqual(
-		left(["Form element `bob` not found."]),
+	expect(getValue({ name: "bob" })()).toStrictEqual(
+		left(["Form element at `[name=bob]` not found."]),
 	)
 })
 
@@ -82,8 +82,8 @@ test("gets the value from textareas", () => {
 	)
 })
 
-test("returns an error Left<Array<string>> on wrong element type", () => {
-	expect(getValue({ name: "button", tagName: "BUTTON" })()).toStrictEqual(
-		left(["Element `button` is not a recognized form element"]),
+test("returns an error Left<Array<string>> on bad selector", () => {
+	expect(getValue({ name: "button", tagName: "OUTPUT" })()).toStrictEqual(
+		left(["Form element at `OUTPUT[name=button]` not found."]),
 	)
 })

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -25,12 +25,13 @@ export const SbOperationTags = {
 } as const
 
 export const SbInjectorType = {
-	constant: "constant",
 	argument: "argument",
+	constant: "constant",
+	element: "element",
 	form: "form",
-	session: "session",
 	local: "local",
 	map: "map",
+	session: "session",
 	table: "table",
 } as const
 
@@ -56,15 +57,22 @@ export interface SbInjectArgument<Type extends SbCastableValue>
 export interface SbFormInjectorData {
 	form?: string
 	id?: string
-	name: string
+	name?: string
 	selector?: string
-	tagName: string
+	tagName?: string
 }
 
 export interface SbInjectFromForm<Type extends SbCastableValue>
 	extends SbInjectValueBase {
 	injectedDataType: Type
 	type: typeof SbInjectorType.form
+	source: SbFormInjectorData
+}
+
+export interface SbInjectFromElement<Type extends SbCastableValue>
+	extends SbInjectValueBase {
+	injectedDataType: Type
+	type: typeof SbInjectorType.element
 	source: SbFormInjectorData
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sitebender/operations",
-	"version": "0.0.33",
+	"version": "0.0.34",
 	"description": "Operations module for configured algorithmic operations.",
 	"license": "MIT",
 	"author": "Charles F. Munat <coder@craft-code.dev>",


### PR DESCRIPTION
I need to be able to get values from `<output>` elements. As you're busy, I've updated things to add an `injectFromElement` and took the opportunity to fix a couple of things.

I made all of the `source` properties optional for the moment. I added a `getSelector` function that creates a CSS selector from the `source` object, going for the highest specificity to ensure getting the right object. We need to be able to select HTML elements in any fashion, not just by name.

Also, there is no need for the `tagName` when searching by name. It just ups specificity. But we should never be searching for elements that are not part of the HTML spec, so no `<foo>` elements.

Caught a few other things and fixed tests. Hoping this doesn't conflict with anything you're doing. If it does, I'm OK with fixing the merge conflicts.